### PR TITLE
Added code markers around openssl command

### DIFF
--- a/configuring-staticman-hugo/comment-1592742710892.yml
+++ b/configuring-staticman-hugo/comment-1592742710892.yml
@@ -1,4 +1,4 @@
 _id: 2e663d50-b3bb-11ea-9e8c-0903d03c6c3b
 name: Onion Samson
-comment: "Hi Julio,\r\n\r\nThanks to a friend (@koralatov), I've been able to generate and retrieve key.pem for step 6:\r\n\r\n> openssl genrsa --out key.pem; cat key.pem\r\n\r\nThen, \"save session\" at bottom-right of the console."
+comment: "Hi Julio,\r\n\r\nThanks to a friend (@koralatov), I've been able to generate and retrieve key.pem for step 6:\r\n\r\n`openssl genrsa --out key.pem; cat key.pem`\r\n\r\nThen, \"save session\" at bottom-right of the console."
 date: '2020-06-21T12:31:50.889Z'


### PR DESCRIPTION
With this, the Markdown parser rendered the two dashes as an en-dash,
preventing copying and pasting of the command.